### PR TITLE
add objectIdField option

### DIFF
--- a/ClusterFeatureLayer.js
+++ b/ClusterFeatureLayer.js
@@ -114,6 +114,8 @@ define([
       this._where = options.where || null;
       this._returnLimit = options.returnLimit || 1000;
 
+      this._objectIdField = options.objectIdField || 'OBJECTID';
+
       if (!this.url) {
         throw new Error('url is a required parameter');
       }
@@ -229,7 +231,7 @@ define([
       this._clusterData.length = 0;
       if (results.features.length) {
         arrayUtils.forEach(results.features, function(feat) {
-          this._clusterCache[feat.attributes.OBJECTID] = feat;
+          this._clusterCache[feat.attributes[this._objectIdField]] = feat;
         }, this);
         this._clusterData = results.features;
       }


### PR DESCRIPTION
Add objectIdField option and _objectIdField class property to allow user
to set the object id field. Use _objectIdField property in
_onFeaturesReturned method to access object id property by key.
