### PR TITLE
Cluster labels do not work with print task

### DIFF
--- a/ClusterFeatureLayer.js
+++ b/ClusterFeatureLayer.js
@@ -638,7 +638,7 @@ define([
       }
 
       // show number of points in the cluster
-      var label = new TextSymbol(c.attributes.clusterCount)
+      var label = new TextSymbol(c.attributes.clusterCount.toString())
         .setColor(new Color(this._clusterLabelColor))
         .setOffset(0, this._clusterLabelOffset)
         .setFont(this._font);
@@ -687,7 +687,7 @@ define([
       if ( label.length == 1 ) {
         // console.log('update label...found: ', label);
         this.remove(label[0]);
-        var newLabel = new TextSymbol(c.attributes.clusterCount)
+        var newLabel = new TextSymbol(c.attributes.clusterCount.toString())
           .setColor(new Color(this._clusterLabelColor))
           .setOffset(0, this._clusterLabelOffset)
           .setFont(this._font);


### PR DESCRIPTION
When using the esri print task with the cluster layer it will not print the labels because the values are set to an integer value rather than a
string. This pull request simply sets the cluster text to be a string value.
